### PR TITLE
use milliseconds for Start-Sleep

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ exports.getActiveWindow = function(callback,repeats,interval){
 
   parameters  = config.parameters;
   parameters.push(repeats);
-  parameters.push(interval);
+  parameters.push(process.platform == 'win32' ? (interval * 1000 | 0) : interval);
 
   //Run shell script
   const ls  = spawn(config.bin,parameters);

--- a/scripts/windows.ps1
+++ b/scripts/windows.ps1
@@ -16,8 +16,8 @@ try {
 		$Process = Get-Process | ? {$_.MainWindowHandle -eq $activeHandle}
 		$string =  $Process | Select ProcessName, @{Name="AppTitle";Expression= {($_.MainWindowTitle)}}
 		Write-Host -NoNewline $string
-		Start-Sleep -s $interval
-		If ($n -gt 0) {$n-=1} 
+		Start-Sleep -m $interval
+		If ($n -gt 0) {$n-=1}
 	}
 } catch {
  Write-Error "Failed to get active Window details. More Info: $_"


### PR DESCRIPTION
Use milliseconds for Start-Sleep, otherwise seconds less than 1 will be rounded down to 0 and that will cause PowerShell to use 100% CPU.

```
Parameter Set: Seconds
Start-Sleep [-Seconds] <Int32> [ <CommonParameters>]

Parameter Set: Milliseconds
Start-Sleep -Milliseconds <Int32> [ <CommonParameters>]
```

See also: https://technet.microsoft.com/en-us/library/hh849939.aspx

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/octalmage/active-window/7)

<!-- Reviewable:end -->
