### PR TITLE
Add try-catch for the window title check script on OSX.

### DIFF
--- a/scripts/mac.scpt
+++ b/scripts/mac.scpt
@@ -6,7 +6,9 @@ tell application "System Events"
 	set frontAppName to name of frontApp
 	tell process frontAppName
 		tell (1st window whose value of attribute "AXMain" is true)
-			set windowTitle to value of attribute "AXTitle"
+			try
+				set windowTitle to value of attribute "AXTitle"
+			end try
 		end tell
 	end tell
 end tell


### PR DESCRIPTION
This cool script failed and my node application crashed when the windowless Java app was started in the background and automatically got 'focused' on OSX El Capitan 10.11.6. Instead of crashing lets just return empty string as a active window title.
