### PR TITLE
Multiple calls to getActiveWindow fails.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+
+export function getActiveWindow(callback: (window: any)=>void, repeats: number, interval: number) : void

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var config = getConfig();
 
 /**
  * This callback handle the response request by getActiveWindow function
@@ -24,6 +23,7 @@ exports.getActiveWindow = function(callback,repeats,interval){
     repeats = '\\-1';
   }
 
+  var config = getConfig();
   parameters  = config.parameters;
   parameters.push(repeats);
   parameters.push(process.platform == 'win32' ? (interval * 1000 | 0) : interval);


### PR DESCRIPTION
This is a quick fix to where multiple calls to getActiveWindow() fails because its config.parameters keeps accumulating more and more parameters (repeats & interval).

I've also added a typescript declaration file, so people can use it from typescript. (Which is where I use it.)