### PR TITLE
Fix mac scpt, add exit() to properly kill child process

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ exports.getActiveWindow = function(callback,repeats,interval){
 
   //Obtain error response from script
   ls.stderr.on("data",function(stderr){
-   throw stderr.toString();
+   throw new Error(stderr.toString());
   });
 
   ls.stdin.end();

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var fs = require('fs');
 var config = getConfig();
+const spawn = require('child_process').spawn;
+var ls;
 
 /**
  * This callback handle the response request by getActiveWindow function
@@ -14,8 +16,7 @@ var config = getConfig();
 * @param {float}   [interval = 0] - Loop interval in seconds. For milliseconds use fraction (0.1 = 100ms)
 */
 exports.getActiveWindow = function(callback,repeats,interval){
-  const spawn = require('child_process').spawn;
-
+  
   interval = (interval) ?  interval : 0;
   repeats = (repeats) ? repeats : 1;
 
@@ -29,7 +30,7 @@ exports.getActiveWindow = function(callback,repeats,interval){
   parameters.push(process.platform == 'win32' ? (interval * 1000 | 0) : interval);
 
   //Run shell script
-  const ls  = spawn(config.bin,parameters);
+  ls = spawn(config.bin,parameters);
   ls.stdout.setEncoding('utf8');
 
   //Obtain successful response from script
@@ -43,6 +44,10 @@ exports.getActiveWindow = function(callback,repeats,interval){
   });
 
   ls.stdin.end();
+}
+
+exports.exit = function(){
+  if(ls) ls.kill(); 
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -67,8 +67,8 @@ function reponseTreatment(response){
     window.title = response[1];
   }else if(process.platform == 'darwin'){
     response = response.split(",");
-    window.app = response[0];
-    window.title = response[1].replace(/\n$/, "").replace(/^\s/, "");
+    window.app = response.shift();
+    window.title = response.join().replace(/\n$/, "").replace(/^\s/, "");
   }
   return window;
 }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ exports.getActiveWindow = function(callback,repeats,interval){
     repeats = '\\-1';
   }
 
-  parameters  = config.parameters;
+  const parameters  = config.parameters.slice();
   parameters.push(repeats);
   parameters.push(process.platform == 'win32' ? (interval * 1000 | 0) : interval);
 

--- a/scripts/mac.scpt
+++ b/scripts/mac.scpt
@@ -2,12 +2,15 @@
 global frontApp, frontAppName, windowTitle
 set windowTitle to ""
 tell application "System Events"
-	set frontApp to first application process whose frontmost is true
-	set frontAppName to name of frontApp
-	tell process frontAppName
-		tell (1st window whose value of attribute "AXMain" is true)
-			set windowTitle to value of attribute "AXTitle"
-		end tell
-	end tell
+    set frontApp to first application process whose frontmost is true
+    set frontAppName to name of frontApp
+    set windowTitle to "no window"
+    tell process frontAppName
+        if exists (1st window whose value of attribute "AXMain" is true) then
+            tell (1st window whose value of attribute "AXMain" is true)
+                set windowTitle to value of attribute "AXTitle"
+            end tell
+        end if
+    end tell
 end tell
 return {frontAppName,windowTitle}


### PR DESCRIPTION
add export.exit() to kill the child process

fix mac.scpt bug