### PR TITLE
Update linux app name

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ function reponseTreatment(response){
   window = {};
   if(process.platform == 'linux'){
     response = response.replace(/(WM_CLASS|WM_NAME)(\(\w+\)\s=\s)/g,'').split("\n",2);
-    window.app = response[0];
+    window.app = response[0].split(',')[0].replace(/"/g, '').trim()
+    window.appClass = response[0].split(',')[1].replace(/"/g, '').trim()
     window.title = response[1];
   }else if (process.platform == 'win32'){
     response = response.replace(/(@{ProcessName=| AppTitle=)/g,'').slice(0,-1).split(';',2);

--- a/index.js
+++ b/index.js
@@ -54,9 +54,9 @@ function reponseTreatment(response){
   window = {};
   if(process.platform == 'linux'){
     response = response.replace(/(WM_CLASS|WM_NAME)(\(\w+\)\s=\s)/g,'').split("\n",2);
-    window.app = response[0].split(',')[0].replace(/"/g, '').trim()
-    window.appClass = response[0].split(',')[1].replace(/"/g, '').trim()
-    window.title = response[1];
+    window.app = response[0].split(',')[0].replace(/"/g, '').trim();
+    window.appClass = response[0].split(',')[1].replace(/"/g, '').trim();
+    window.title = response[1].replace(/"/g, '').trim();
   }else if (process.platform == 'win32'){
     response = response.replace(/(@{ProcessName=| AppTitle=)/g,'').slice(0,-1).split(';',2);
     window.app = response[0];


### PR DESCRIPTION
Right now the Linux `window.app` contains a string like:  `"gnome-terminal-server", "Gnome-terminal"` (including the `"`).

It seems that there is an app name and an app class name [here's my reference](https://tronche.com/gui/x/icccm/sec-4.html#WM_CLASS).

This PR makes the `window.app` contain (in that case): `gnome-terminal-server`
And also it adds an additional `window.appClass` that contains (in that case): `Gnome-terminal`.

The additional `window.appClass` is only set when the system is Linux. If you want, I can set it to an empty string in Windows an Mac, just to have a common interface and avoid compatibility issues.