### PR TITLE
Return child process

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@
 
 Compatible with Linux, Windows 7+, and OSX;
 
+## Description
+
+This module exports a `getActiveWindow()` function that takes as parameters:
+
+* `callback`: a function to process the results, given as a parameter to that callback. The parameter will be a `window` object with:
+  * `app`: the name of the app running, the process name (e.g. `chrome`).
+  * `title`: the title of the active window (e.g. `Facebook`).
+
+The `return` of the `getActiveWindow()` function is a Node.js [`ChildProcess`](https://nodejs.org/api/child_process.html#child_process_class_childprocess) object. So you can, for example, kill that child process with the `.kill()` method.
+
 ## Usage
 
 ```javascript
@@ -14,34 +24,39 @@ callback = function(window){
     console.log("Title: " + window.title);
   }catch(err) {
       console.log(err);
-  } 
+  }
 }
-/*Watch the active window 
+/*Watch the active window
   @callback
-  @number of requests; infinity = -1 
+  @number of requests; infinity = -1
   @interval between requests
 */
 //monitor.getActiveWindow(callback,-1,1);
 
 //Get the current active window
-monitor.getActiveWindow(callback);
+var monitorProcess = monitor.getActiveWindow(callback);
 
+// After some time, or right before closing your app,
+// you might want to kill the subprocess
+monitorProcess.kill();
 
 ```
+
 ## Tested on
 - Windows
  - Windows 10
  - Windows 7
-- Linux 
+- Linux
   - Raspbian [lxdm]
   - Debian 8 [cinnamon]
+  - Ubuntu 16.04
 - OSX
   - Yosemite 10.10.1
 
 ## TODO
 
 - Test on more operating systems.
-- Use native APIs. 
+- Use native APIs.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ callback = function(window){
 //Get the current active window
 var monitorProcess = monitor.getActiveWindow(callback);
 
-// After some time, or right before closing your app,
-// you might want to kill the subprocess
+// If you used -1 in the "repeats" parameter (infinity), after some time
+// or right before closing your app, you might want to kill the subprocess
 monitorProcess.kill();
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This module exports a `getActiveWindow()` function that takes as parameters:
 * `callback`: a function to process the results, given as a parameter to that callback. The parameter will be a `window` object with:
   * `app`: the name of the app running, the process name (e.g. `chrome`).
   * `title`: the title of the active window (e.g. `Facebook`).
+* `repeats` (defaults to `1`): The number of times it should get the active window.
+* `interval` (defaults to `0`): the interval in seconds between each request.
 
 The `return` of the `getActiveWindow()` function is a Node.js [`ChildProcess`](https://nodejs.org/api/child_process.html#child_process_class_childprocess) object. So you can, for example, kill that child process with the `.kill()` method.
 
@@ -28,7 +30,7 @@ callback = function(window){
 }
 /*Watch the active window
   @callback
-  @number of requests; infinity = -1
+  @repeats of requests; infinity = -1
   @interval between requests
 */
 //monitor.getActiveWindow(callback,-1,1);

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ exports.getActiveWindow = function(callback,repeats,interval){
   });
 
   ls.stdin.end();
+
+  return ls;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -54,7 +54,8 @@ function reponseTreatment(response){
   window = {};
   if(process.platform == 'linux'){
     response = response.replace(/(WM_CLASS|WM_NAME)(\(\w+\)\s=\s)/g,'').split("\n",2);
-    window.app = response[0];
+    window.app = response[0].split(',')[0].replace(/"/g, '').trim()
+    window.appClass = response[0].split(',')[1].replace(/"/g, '').trim()
     window.title = response[1];
   }else if (process.platform == 'win32'){
     response = response.replace(/(@{ProcessName=| AppTitle=)/g,'').slice(0,-1).split(';',2);

--- a/index.js
+++ b/index.js
@@ -54,9 +54,9 @@ function reponseTreatment(response){
   window = {};
   if(process.platform == 'linux'){
     response = response.replace(/(WM_CLASS|WM_NAME)(\(\w+\)\s=\s)/g,'').split("\n",2);
-    window.app = response[0].split(',')[0].replace(/"/g, '').trim()
-    window.appClass = response[0].split(',')[1].replace(/"/g, '').trim()
-    window.title = response[1];
+    window.app = response[0].split(',')[0].replace(/"/g, '').trim();
+    window.appClass = response[0].split(',')[1].replace(/"/g, '').trim();
+    window.title = response[1].replace(/"/g, '').trim();
   }else if (process.platform == 'win32'){
     response = response.replace(/(@{ProcessName=| AppTitle=)/g,'').slice(0,-1).split(';',2);
     window.app = response[0];


### PR DESCRIPTION
Return the NodeJS child process from the invocation of `getActiveWindow()`.

Currently, if `getActiveWindow()` is called with a `repeats` equal to `-1` (infinity), there's no way to finish the process at some point. So, the process will keep "dangling".

With this change, the subprocess could be retrieved and manually killed as in:

```javascript
var monitorProcess = monitor.getActiveWindow(callback, -1);
monitorProcess.kill();
```

I also updated the README to explain the parameters and the return of the `ChildProcess`.