### PR TITLE
Rebuild titles containing commas, on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Compatible with Linux, Windows 7+, and OSX;
 ```javascript
 var monitor = require('active-window');
 
-callback = function(window){
-  try {
+callback = function(err, window){
+  if (err){
+    console.error(err);
+  } else {
     console.log("App: " + window.app);
     console.log("Title: " + window.title);
-  }catch(err) {
-      console.log(err);
-  } 
+  }
 }
 /*Watch the active window 
   @callback

--- a/index.js
+++ b/index.js
@@ -62,8 +62,9 @@ function reponseTreatment(response){
     window.title = response[1];
   }else if(process.platform == 'darwin'){
     response = response.split(",");
-    window.app = response[0];
-    window.title = response[1].replace(/\n$/, "").replace(/^\s/, "");
+    window.app = response.shift();
+    response.map(r => r.replace(/\n$/, "").replace(/^\s/, ""));
+    window.title = response.join(",");
   }
   return window;
 }

--- a/index.js
+++ b/index.js
@@ -27,19 +27,19 @@ exports.getActiveWindow = function(callback,repeats,interval){
   parameters  = config.parameters;
   parameters.push(repeats);
   parameters.push(process.platform == 'win32' ? (interval * 1000 | 0) : interval);
-
+  
   //Run shell script
   const ls  = spawn(config.bin,parameters);
   ls.stdout.setEncoding('utf8');
 
   //Obtain successful response from script
   ls.stdout.on('data', function(stdout){
-    callback(reponseTreatment(stdout.toString()));
+    callback(null,reponseTreatment(stdout.toString()));
   });
 
   //Obtain error response from script
   ls.stderr.on("data",function(stderr){
-   throw stderr.toString();
+    callback(new Error(stderr.toString()), null);
   });
 
   ls.stdin.end();

--- a/index.js
+++ b/index.js
@@ -63,8 +63,7 @@ function reponseTreatment(response){
   }else if(process.platform == 'darwin'){
     response = response.split(",");
     window.app = response.shift();
-    response.map(r => r.replace(/\n$/, "").replace(/^\s/, ""));
-    window.title = response.join(",");
+    window.title = response.join(",").replace(/\n$/, "").replace(/^\s/, "");
   }
   return window;
 }

--- a/scripts/mac.scpt
+++ b/scripts/mac.scpt
@@ -1,13 +1,15 @@
-#!/usr/bin/env osascript
 global frontApp, frontAppName, windowTitle
 set windowTitle to ""
 tell application "System Events"
 	set frontApp to first application process whose frontmost is true
 	set frontAppName to name of frontApp
+	set windowTitle to "no window"
 	tell process frontAppName
-		tell (1st window whose value of attribute "AXMain" is true)
-			set windowTitle to value of attribute "AXTitle"
-		end tell
+		if exists (1st window whose value of attribute "AXMain" is true) then
+			tell (1st window whose value of attribute "AXMain" is true)
+				set windowTitle to value of attribute "AXTitle"
+			end tell
+		end if
 	end tell
 end tell
 return {frontAppName,windowTitle}

--- a/scripts/mac.scpt
+++ b/scripts/mac.scpt
@@ -1,3 +1,4 @@
+#!/usr/bin/env osascript
 global frontApp, frontAppName, windowTitle
 set windowTitle to ""
 tell application "System Events"


### PR DESCRIPTION
Sometimes window titles contain commas, which leads to window.title incorrectly cutting off the end of the title
e.g: If the window's full title is Lions and tigers and bears, oh my!, window.title is set to Lions and tigers and bears

This pull request fixes this behaviour on macOS
I suggest making a similar change for Windows and Linux if they also present the same behaviour, I don't have those OSes handy to understand the output on those platforms