### PR TITLE
Pass errors to callback instead of throwing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Compatible with Linux, Windows 7+, and OSX;
 ```javascript
 var monitor = require('active-window');
 
-callback = function(window){
-  try {
+callback = function(err, window){
+  if (err){
+    console.error(err);
+  } else {
     console.log("App: " + window.app);
     console.log("Title: " + window.title);
-  }catch(err) {
-      console.log(err);
-  } 
+  }
 }
 /*Watch the active window 
   @callback

--- a/index.js
+++ b/index.js
@@ -27,19 +27,19 @@ exports.getActiveWindow = function(callback,repeats,interval){
   parameters  = config.parameters;
   parameters.push(repeats);
   parameters.push(process.platform == 'win32' ? (interval * 1000 | 0) : interval);
-
+  
   //Run shell script
   const ls  = spawn(config.bin,parameters);
   ls.stdout.setEncoding('utf8');
 
   //Obtain successful response from script
   ls.stdout.on('data', function(stdout){
-    callback(reponseTreatment(stdout.toString()));
+    callback(null,reponseTreatment(stdout.toString()));
   });
 
   //Obtain error response from script
   ls.stderr.on("data",function(stderr){
-   throw stderr.toString();
+    callback(new Error(stderr.toString()), null);
   });
 
   ls.stdin.end();


### PR DESCRIPTION
Use the `callback(err, data)` pattern for error handling.   

Throwing the error causes node to crash because `ls.stderr.on()` does not catch the error   
Using the `callback(err, data)` pattern allows the developer to handle the error:   
```javascript
callback = function(err, window){
  if (err){
    console.error(err);
  } else {
    console.log("App: " + window.app);
    console.log("Title: " + window.title);
  }
}
```